### PR TITLE
Change regex in validate method (overwritten)

### DIFF
--- a/Model/Card.php
+++ b/Model/Card.php
@@ -406,7 +406,7 @@ class Card extends Cc
         $supportType = [
             "AE" => "American Express",
             "VI" => "Visa",
-            "MC" => "Master Card"
+            "MC" => "MasterCard"
         ];
         $out = [];
         foreach ($activeTypes AS $value) {
@@ -513,11 +513,11 @@ class Card extends Cc
             if ($this->validateCcNumOther($binNumber)) {
                 $ccTypeRegExpList = [
                     // Visa
-                    'VI' => '/^4[0-9]{6}([0-9]{4})?$/',
-                    // Master Card
-                    'MC' => '/^5[1-5][0-9]{10}$/',
+                    'VI' => '/^4[0-9]{12}([0-9]{3})?$/',
+                    // MasterCard
+                    'MC' => '/^(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}$/',
                     // American Express
-                    'AE' => '/^3[47][0-9]{10}$/',
+                    'AE' => '/^3[47][0-9]{13}$/',
                 ];
 
                 // Validate only main brands.


### PR DESCRIPTION
MasterCard added a new series of credit card numbers recently, the 2-series.
Magento added official support for the new 2-series CC numbers in recent versions,
but many Magento sites are still running older uncompliant versions.

-Change regex in validate method in plugin Conekta.
-Fix name of allowed types.

Tests.
`MasterCard Logs`
59df95f5edbb6e07bd6d4155 => 5555 5555 5555 4444
59df9755ffecf95c31cace69    => 2223 0000 4841 0010

`VISA Logs`
59df9681b795b028afc17a5e   => 4012 8888 8888 1881

`American Express Logs`
59df9710ffecf978a0cb1ab1     => 371449635398431

If you want test it, you can run a Magento 2 Docker and install plugin.
`docker run -d --net=bridge --restart=always --privileged -h m2ce --name m2ce -it -p 80:80 -p 443:443 -p 22:22 -p 3306:3306 -p 3333:3333 jdavidvr/m2ce:1.0`


