### PR TITLE
Fix on webhook bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2.0.2](https://github.com/conekta/conekta-magento2/releases/tag/v2.0.2) - 2018-10-09
+### Fix
+- Fix on webhook bug
+
 ## [2.0.1](https://github.com/conekta/conekta-magento2/releases/tag/v2.0.1) - 2017-08-31
 ### Fix
 - Hotfix at instantiation of webhook observer

--- a/Controller/Webhook/Index.php
+++ b/Controller/Webhook/Index.php
@@ -18,9 +18,9 @@ class Index extends Action
         
         if ($charge->status === "paid"){
             try{ 
-                $order->loadByIncrementId($charge->reference_id);
-                $order->setSate(Order::STATE_PROCESSING);
-                $order->setStatus(Order::STATE_PROCESSING);
+                $order->loadByIncrementId($charge->metadata->checkout_id);
+                $order->setSate(Order::STATE_COMPLETE);
+                $order->setStatus(Order::STATE_COMPLETE);
                 
                 $order->addStatusHistoryComment("Payment received successfully")
                         ->setIsCustomerNotified(true);

--- a/Model/Config.php
+++ b/Model/Config.php
@@ -126,7 +126,7 @@ class Config extends \Magento\Payment\Model\Method\AbstractMethod {
             \Conekta\Conekta::setApiKey($privateKey);
             \Conekta\Conekta::setApiVersion("2.0.0");
             \Conekta\Conekta::setPlugin("Magento 2");
-            \Conekta\Conekta::setPluginVersion("2.0.1");
+            \Conekta\Conekta::setPluginVersion("2.0.2");
             \Conekta\Conekta::setLocale($locale);
         }catch(\Exception $e){
             throw new \Magento\Framework\Validator\Exception(

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![alt tag](https://raw.github.com/conekta/conekta-magento/master/readme_files/cover.png)
 
-Magento 2 Plugin v.2.0.1 (Stable)
+Magento 2 Plugin v.2.0.2 (Stable)
 ========================
 
 Installation

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "conekta/conekta_payments",
     "description": "Conekta rules!",
     "type": "magento2-module",
-    "version": "2.0.0",
+    "version": "2.0.2",
     "minimum-stability": "stable",
     "require": {
         "conekta/conekta-php": "*"

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Conekta_Payments" setup_version="2.0.0">
+	<module name="Conekta_Payments" setup_version="2.0.2">
         <sequence>
             <module name="Magento_Core"/>
             <module name="Magento_Sales" />


### PR DESCRIPTION
Why is this change neccesary?
Orders created on Magento aren't updating correctly.

How does it address the issue?
It points to the correct attribute needed by Magento in order to update the order, it also sets the correct status.